### PR TITLE
Fix: restore per-zone channel in play_url (revert channel regression)

### DIFF
--- a/vsslctrl/api_alpha.py
+++ b/vsslctrl/api_alpha.py
@@ -1778,7 +1778,7 @@ class APIAlpha(APIBase):
         # that connection's perspective. Previously this sent self.zone.id, which
         # produced no playback on multi-zone units for zones with id > 1 (verified
         # on an A.6x: zone 4 never played with channel byte 4; channel 1 works).
-        channel = 0 if all_zones else 1
+        channel = 0 if all_zones else self.zone.id
         command.extend([channel])
 
         # Volume — the announcement plays at `volume` (0-100), falling back to the


### PR DESCRIPTION
The channel change in the earlier announce-volume PR set the CMD 55 channel byte to a constant 1, which forces every announcement onto physical zone 1. On multi-zone units (e.g. A.6x) this sends all zone-2..6 announcements to zone 1 instead of the targeted zone.

The channel byte is simply the zone number, so restore channel = 0 if all_zones else self.zone.id (the original behaviour).

Why the regression happened: the original change was based on a flawed verification method. Whether a channel byte 'worked' was judged by watching for the amp to fetch the audio file over HTTP -- but the A.6x always fetches via its primary interface (and/or serves it from cache) regardless of the targeted zone, so the absence of a fresh fetch was misread as 'that zone didn't play.' The reliable signal is the amp's own per-zone transport state (or in-room audio). Reading transport state while firing each byte confirms channel = zone number:

    channel 1 -> zone 1 (Living)      channel 4 -> zone 4 (Master Bedroom)
    channel 2 -> zone 2 (Master Bath) channel 5 -> zone 5 (Upstairs)
    channel 3 -> zone 3 (Garage)      channel 6 -> zone 6 (Backyard)